### PR TITLE
fix: standardize notification unread-count response format

### DIFF
--- a/internal/handler/notification_handler.go
+++ b/internal/handler/notification_handler.go
@@ -45,7 +45,7 @@ func (h *NotificationHandler) GetUnreadCount(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	return c.JSON(fiber.Map{"unread_count": count})
+	return c.JSON(fiber.Map{"message": "success", "data": fiber.Map{"unread_count": count}})
 }
 
 // MarkAsRead PATCH /api/notifications/:id/read


### PR DESCRIPTION
## Summary
- Chuẩn hóa response của `GET /notifications/unread-count` từ `{"unread_count": N}` thành `{"message": "success", "data": {"unread_count": N}}` cho consistent với các endpoint khác

## Test plan
- [ ] Gọi `GET /api/notifications/unread-count` verify response format `{message, data}`
- [ ] Verify FE notification bell hiển thị đúng unread count