### PR TITLE
fix: standardize unread-count response to data-only format

### DIFF
--- a/internal/handler/notification_handler.go
+++ b/internal/handler/notification_handler.go
@@ -45,7 +45,7 @@ func (h *NotificationHandler) GetUnreadCount(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	return c.JSON(fiber.Map{"message": "success", "data": fiber.Map{"unread_count": count}})
+	return c.JSON(fiber.Map{"data": fiber.Map{"unread_count": count}})
 }
 
 // MarkAsRead PATCH /api/notifications/:id/read


### PR DESCRIPTION
## Summary
- Bỏ field `"message": "success"` thừa khỏi response `GET /notifications/unread-count`
- Giữ wrapper `{"data": {"unread_count": count}}` — đồng nhất pattern `data`-only với `ListNotifications`, `GetSettings`, và các handler khác
- FE (`notification.service.ts`) đọc `r.data.data` → không cần thay đổi phía frontend

## Test plan
- [x] `go build ./...` — pass
- [x] `go vet ./...` — pass
- [x] Kiểm tra FE TypeScript type chain: `UnreadCountResponse.unread_count` khớp response mới
- [x] Kiểm tra `header.tsx` consume `unreadData?.unread_count` — đúng
- [x] Kiểm tra các handler khác trong file — format nhất quán